### PR TITLE
Replace deprecated get_feature_names

### DIFF
--- a/src/bitermplus/_util.py
+++ b/src/bitermplus/_util.py
@@ -51,7 +51,7 @@ def get_words_freqs(
     """
     vec = CountVectorizer(**kwargs)
     X = vec.fit_transform(docs)
-    words = np.array(vec.get_feature_names())
+    words = np.array(vec.get_feature_names_out())
     return X, words, vec.vocabulary_
 
 


### PR DESCRIPTION
get_words_freqs currently throws a FutureWarning: Function get_feature_names is deprecated; get_feature_names is deprecated in 1.0 and will be removed in 1.2. Please use get_feature_names_out instead.